### PR TITLE
Feature : access token발급

### DIFF
--- a/src/apis/test.ts
+++ b/src/apis/test.ts
@@ -1,0 +1,11 @@
+import { publicInstance } from '@/libs/axios';
+import type { CommonResponseDto } from '@/types/commonResponseDto';
+
+type getAccessTokenResponseDto = CommonResponseDto<string>;
+
+export const getAccessToken = async (): Promise<getAccessTokenResponseDto> => {
+  const { data } = await publicInstance.get('/api/users/1');
+  localStorage.setItem('accessToken', data.result);
+  console.log(`accessToken 업데이트 : ${data.result}`);
+  return data;
+};

--- a/src/layout/components/AuthMenu.tsx
+++ b/src/layout/components/AuthMenu.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Link, useNavigate } from 'react-router-dom';
 
+import { getAccessToken } from '@/apis/test';
 import Alert from '@/assets/images/Alert.png';
 import Chat from '@/assets/images/Chat.png';
 import HeaderProfile from '@/assets/images/HeaderProfile.png';
@@ -21,7 +22,10 @@ function AuthMenu() {
       {/* 로그인토글버튼추가 */}
       <button
         type="button"
-        onClick={toggleLoggedIn}
+        onClick={() => {
+          if (!isLoggedIn) getAccessToken();
+          toggleLoggedIn();
+        }}
         className="mr-6 rounded-md bg-orange-300 px-3 py-1 text-sm text-white"
       >
         {isLoggedIn ? '로그아웃할래' : '로그인할래'}

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -5,30 +5,30 @@ export const publicInstance = axios.create({
   baseURL: import.meta.env.VITE_SERVER_API_URL,
   headers: { 'Content-Type': 'application/json' },
   timeout: 10_000, //10
-  withCredentials: false, // 쿠키·세션 차단
+  withCredentials: false, // 쿠키/세션 차단 속성
   validateStatus: (status) => status < 500, // 4xx도 클라이언트에서 처리
 });
 
 // https://medium.com/%40velja/token-refresh-with-axios-interceptors-for-a-seamless-authentication-experience-854b06064bde
 // 여기서 찾은 권장패턴입니다. 추후 활성화
-// // 토큰 포함 인스턴스
-// export const privateInstance = axios.create({
-//   baseURL: import.meta.env.VITE_SERVER_BASE_URL,
-//   //   headers: { 'Content-Type': 'application/json' },
-//   //   timeout: 10_000,
-// });
+// 토큰 포함 인스턴스
+export const privateInstance = axios.create({
+  baseURL: import.meta.env.VITE_SERVER_BASE_URL,
+  //   headers: { 'Content-Type': 'application/json' },
+  //   timeout: 10_000,
+});
 
-// //요청 인터셉터로 토큰 자동 주입
-// privateInstance.interceptors.request.use(
-//   (request) => {
-//     const accessToken = localStorage.getItem('accessToken');
-//     if (accessToken) {
-//       request.headers['Authorization'] = `Bearer ${accessToken}`;
-//     }
-//     return request;
-//   },
-//   (error) => Promise.reject(error),
-// );
+//요청 인터셉터로 토큰 자동 주입
+privateInstance.interceptors.request.use(
+  (request) => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      request.headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+    return request;
+  },
+  (error) => Promise.reject(error),
+);
 
 // // 응답 인터셉터 - 401일 때 리프레쉬 토큰을 이용하여 액세스 토큰 재발급
 // privateInstance.interceptors.response.use(

--- a/src/types/commonResponseDto.ts
+++ b/src/types/commonResponseDto.ts
@@ -1,0 +1,8 @@
+// 공통 응답 타입
+// type GetExpertDetailResponseDto = CommonResponse<ExpertDetail[]> 처럼 사용
+export interface CommonResponseDto<T = unknown> {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+}


### PR DESCRIPTION
## 🚀 개요
- accessToekn 발급 api 연결

## ✨ 주요 변경 사항
- src/types/axios.ts 추가 (인스턴스 관리)
- src/apis/text.ts 추가 (test용 accessToken 발급 api 연결)
- src/types/CommonResponseDto.ts 추가 (응답형태 공용 type)
- 헤더 - test용 로그인할래 버튼에 getAccessToken 추가 - localStroage에 accessToken 저장

## 📝 상세 내용
- axios.ts 에 publicInstance, PrivateInstance 만들었습니다.
- PrivateInstance 요청 인터셉터로 localstorage에 토큰 가져오게 했습니다.
- refresh Token을 이용한 자동갱신은 주석처리해놨습니다 (미완성)
- ResponseDto는 CommonResponseDto<result 타입> 으로 사용하시면 됩니다.
- accessToken 필요한 요청은 PrivateInstance 사용하시면 됩니다.
- Token 저장까지 확인했고 토큰 담아서 api 연결되는지는 아직 확인 못한 상태입니다

## ✅ 체크리스트
- [x] 테스트 시 버그 없음
- [x] 브랜치 , PR 컨벤션
- [x] ESLint / Prettier / 타입 오류 없음
- [x] main 브랜치 최신 상태 반영함

## 🖼️ 테스트 결과
